### PR TITLE
Misc fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ app.d
 *.dll
 *.a
 *.so
+ca-lib2

--- a/src/caLib/lattices/OneDimDenseLattice.d
+++ b/src/caLib/lattices/OneDimDenseLattice.d
@@ -214,7 +214,7 @@ public:
         else
         {
             static assert(0, "OneDimDenseLattice getNeighbours method dosen't" 
-                "have a \"" ~ behaviour ~ "\" behaviour");
+                ~ "have a \"" ~ behaviour ~ "\" behaviour");
         }
     }
 

--- a/src/caLib/lattices/TwoDimDenseLattice.d
+++ b/src/caLib/lattices/TwoDimDenseLattice.d
@@ -221,7 +221,7 @@ public:
         else
         {
             static assert(0, "TwoDimDenseLattice getNeighbours method dosen't" 
-                "have a \"" ~ behaviour ~ "\" behaviour");
+                ~ "have a \"" ~ behaviour ~ "\" behaviour");
         }
     }
 


### PR DESCRIPTION
- OneDimDenseLattice and TwoDimDenseLattice no longer use implicit string cincetation
- The executable file generated by dub is now ignored on Linux